### PR TITLE
Create a wildcard DNS entry pointed at Kube's load balancer

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -46,6 +46,7 @@ jobs:
       #     TF_ACTION_WORKING_DIR: terraform/
       #     TF_ACTION_TFE_TOKEN: ${{ secrets.TERRAFORM_TOKEN }}
       #     TF_VAR_digitalocean_token: ${{ secrets.DIGITALOCEAN_TOKEN }}
+      #     TF_VAR_gandi_key:${{ secrets.GANDI_KEY }}
       # - name: terraform-apply
       #   uses: hashicorp/terraform-github-actions/apply@master
       #   if: github.event_name == 'push' && github.ref == 'master'
@@ -54,3 +55,4 @@ jobs:
       #     TF_ACTION_WORKING_DIR: terraform/
       #     TF_ACTION_TFE_TOKEN: ${{ secrets.TERRAFORM_TOKEN }}
       #     TF_VAR_digitalocean_token: ${{ secrets.DIGITALOCEAN_TOKEN }}
+      #     TF_VAR_gandi_key:${{ secrets.GANDI_KEY }}

--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 Everything to Terraform a dead planet into all my personal infrastructure.
 
 ![](https://thumbs.gfycat.com/QuickBronzeBeetle-size_restricted.gif)
+
+## Componenets
+
+***terraform/***
+
+Terraform code for:
+
+- Creating a Kubernetes cluster in DigitalOcean
+- Installing Istio on the cluster
+- Pointing a domain at the cluster's load balancer via a wildcard DNS entry in Gandi.net

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,4 +3,6 @@ module "kubernetes_cluster" {
   digitalocean_token = var.digitalocean_token
   name               = "jdh"
   region             = "sfo2"
+  gandi_key          = var.gandi_key
+  domain             = "yaml.zone"
 }

--- a/terraform/modules/kubernetes_cluster/dns.tf
+++ b/terraform/modules/kubernetes_cluster/dns.tf
@@ -1,0 +1,26 @@
+data "kubernetes_service" "istio_ingressgateway" {
+  depends_on = [helm_release.istio]
+  metadata {
+    name = "istio-ingressgateway"
+    namespace = "istio-system"
+  }
+}
+
+resource "gandi_zone" "default" {
+  name = "${var.domain} Zone"
+}
+
+resource "gandi_zonerecord" "wildcard" {
+  zone = gandi_zone.default.id
+  name = "*"
+  type = "A"
+  ttl = 3600
+  values = [
+    data.kubernetes_service.istio_ingressgateway.load_balancer_ingress.0.ip
+  ]
+}
+
+resource "gandi_domainattachment" "default" {
+  domain = var.domain
+  zone   = gandi_zone.default.id
+}

--- a/terraform/modules/kubernetes_cluster/istio.tf
+++ b/terraform/modules/kubernetes_cluster/istio.tf
@@ -41,7 +41,7 @@ resource "kubernetes_cluster_role_binding" "tiller" {
 
 resource "helm_release" "istio-init" {
   name       = "istio-init"
-  repository = "${data.helm_repository.istio.metadata.0.name}"
+  repository = data.helm_repository.istio.metadata.0.name
   # The version shouldn't be required, but trying to `helm install istio.io/istio-init`
   # with an RC version results in "matching version '' not found in istio.io index".
   chart     = "${data.helm_repository.istio.metadata.0.name}/istio-init"

--- a/terraform/modules/kubernetes_cluster/providers.tf
+++ b/terraform/modules/kubernetes_cluster/providers.tf
@@ -27,3 +27,7 @@ provider "helm" {
     cluster_ca_certificate = base64decode(digitalocean_kubernetes_cluster.default.kube_config.0.cluster_ca_certificate)
   }
 }
+
+provider "gandi" {
+  key = var.gandi_key
+}

--- a/terraform/modules/kubernetes_cluster/variables.tf
+++ b/terraform/modules/kubernetes_cluster/variables.tf
@@ -24,3 +24,9 @@ variable "istio_version" {
   description = "The version of Istio to install"
   default     = "1.3.0-rc.1"
 }
+variable "gandi_key" {
+  description = "Gandi.net API key"
+}
+variable "domain" {
+  description = "A domain to give a wildcard DNS record pointed at Kubernetes' load balancer"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,6 @@
 variable "digitalocean_token" {
   description = "A DigitalOcean API token"
 }
+variable "gandi_key" {
+  description = "A Gandi.net API key"
+}


### PR DESCRIPTION
TBD: The Gandi provider is a community one. How much should that weigh in
deciding whether to stick with using Gandi's DNS (they're my registrar) vs
using DigitalOcean's (we're already using the included DO provider)?

- Is the domain being dedicated to Kubernetes (or other things in DO)?
- Or maybe it's worth $5/month to sign up for DNSimple?