### PR TITLE
Add a domain for our ingress controller to use

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,4 +7,5 @@ module "kubernetes_cluster" {
   digitalocean_token = var.digitalocean_token
   name               = "jdh"
   region             = "sfo2"
+  domain             = "yaml.zone"
 }

--- a/terraform/modules/kubernetes_cluster/dns.tf
+++ b/terraform/modules/kubernetes_cluster/dns.tf
@@ -1,0 +1,3 @@
+resource "digitalocean_domain" "default" {
+  name = var.domain
+}

--- a/terraform/modules/kubernetes_cluster/variables.tf
+++ b/terraform/modules/kubernetes_cluster/variables.tf
@@ -20,3 +20,6 @@ variable "node_size" {
   description = "The size of nodes in the default node pool"
   default     = "s-1vcpu-2gb"
 }
+variable "domain" {
+  description = "The domain name to use with our ingress controller"
+}


### PR DESCRIPTION
No records yet; just an empty DigitalOcean domain so I can point Gandi
at it.

Signed-off-by: Jonathan Hartman <j@hartman.io>