### PR TITLE
Upgrade to Kubernetes 1.18.8

### DIFF
--- a/terraform/modules/kubernetes_cluster/variables.tf
+++ b/terraform/modules/kubernetes_cluster/variables.tf
@@ -10,7 +10,7 @@ variable "region" {
 # The "version" variable name is reserved in modules.
 variable "kubernetes_version" {
   description = "The Kubernetes version"
-  default     = "1.18.6-do.0"
+  default     = "1.18.8-do.0"
 }
 variable "node_count" {
   description = "The number of nodes in the default node pool"


### PR DESCRIPTION
Does Terraform trigger a cluster upgrade operation in DigitalOcean or
does everything explode?

Signed-off-by: Jonathan Hartman <j@hartman.io>