### PR TITLE
Upgrade to Kubernetes 1.20.2

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "= 0.13.4"
+  required_version = "= 0.14.6"
 }
 
 module "kubernetes_cluster" {

--- a/terraform/modules/kubernetes_cluster/providers.tf
+++ b/terraform/modules/kubernetes_cluster/providers.tf
@@ -2,17 +2,17 @@ terraform {
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "~> 1.22"
+      version = "~> 2.5"
     }
 
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.13"
+      version = "~> 2.0"
     }
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 1.3"
+      version = "~> 2.0"
     }
   }
 }
@@ -22,7 +22,6 @@ provider "digitalocean" {
 }
 
 provider "kubernetes" {
-  load_config_file       = false
   host                   = digitalocean_kubernetes_cluster.default.kube_config.0.host
   client_certificate     = base64decode(digitalocean_kubernetes_cluster.default.kube_config.0.client_certificate)
   client_key             = base64decode(digitalocean_kubernetes_cluster.default.kube_config.0.client_key)
@@ -31,7 +30,6 @@ provider "kubernetes" {
 
 provider "helm" {
   kubernetes {
-    load_config_file       = false
     host                   = digitalocean_kubernetes_cluster.default.kube_config.0.host
     client_certificate     = base64decode(digitalocean_kubernetes_cluster.default.kube_config.0.client_certificate)
     client_key             = base64decode(digitalocean_kubernetes_cluster.default.kube_config.0.client_key)

--- a/terraform/modules/kubernetes_cluster/variables.tf
+++ b/terraform/modules/kubernetes_cluster/variables.tf
@@ -10,7 +10,7 @@ variable "region" {
 # The "version" variable name is reserved in modules.
 variable "kubernetes_version" {
   description = "The Kubernetes version"
-  default     = "1.18.8-do.1"
+  default     = "1.20.2-do.0"
 }
 variable "node_count" {
   description = "The number of nodes in the default node pool"


### PR DESCRIPTION
This also bumps the version of Terraform and all the providers used. Terraform Cloud has already been flipped to build on the new version.