### PR TITLE
Roll back to Kubernetes 1.19

### DIFF
--- a/terraform/modules/kubernetes_cluster/variables.tf
+++ b/terraform/modules/kubernetes_cluster/variables.tf
@@ -10,7 +10,7 @@ variable "region" {
 # The "version" variable name is reserved in modules.
 variable "kubernetes_version" {
   description = "The Kubernetes version"
-  default     = "1.20.2-do.0"
+  default     = "1.19.6-do.0"
 }
 variable "node_count" {
   description = "The number of nodes in the default node pool"


### PR DESCRIPTION
DigitalOcean won't even attempt to hop straight from 1.18 to 1.20.

Signed-off-by: Jonathan Hartman <j@hartman.io>