### PR TITLE
Roll back to Kubernetes 1.18.14

### DIFF
--- a/terraform/modules/kubernetes_cluster/variables.tf
+++ b/terraform/modules/kubernetes_cluster/variables.tf
@@ -10,7 +10,7 @@ variable "region" {
 # The "version" variable name is reserved in modules.
 variable "kubernetes_version" {
   description = "The Kubernetes version"
-  default     = "1.19.6-do.0"
+  default     = "1.18.14-do.0"
 }
 variable "node_count" {
   description = "The number of nodes in the default node pool"


### PR DESCRIPTION
This is the last 1.18 available in DigitalOcean. Please let this enable an
upgrade to 1.19.

Signed-off-by: Jonathan Hartman <j@hartman.io>