### PR TITLE
Bump Terraform to 1.0.6

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "= 1.0.5"
+  required_version = "= 1.0.6"
 }
 
 module "kubernetes_cluster" {

--- a/terraform/modules/kubernetes_cluster/providers.tf
+++ b/terraform/modules/kubernetes_cluster/providers.tf
@@ -12,7 +12,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.2"
+      version = "~> 2.3"
     }
   }
 }


### PR DESCRIPTION
TF Cloud is already updated.

Signed-off-by: Jonathan Hartman <j@hartman.io>